### PR TITLE
fix: add the `.pub` extension to the git user.signingkey

### DIFF
--- a/tasks/git.yml
+++ b/tasks/git.yml
@@ -3,6 +3,6 @@
     git config --global user.name "{{ git_name }}"
     git config --global user.email "{{ git_email }}"
     git config --global gpg.format ssh
-    git config --global user.signingkey ~/.ssh/{{ git_ssh_key }}
+    git config --global user.signingkey ~/.ssh/{{ git_ssh_key }}.pub
     git config --global pull.rebase false
     git config --global init.defaultBranch main


### PR DESCRIPTION
see: https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key