### PR TITLE
fix: make updates work from zoom.yml setup

### DIFF
--- a/tasks/zoom.yml
+++ b/tasks/zoom.yml
@@ -6,7 +6,7 @@
     description: Zoom repository
     file: zoom
     baseurl: https://repo.zoom.us/repo/rpm/release/
-    gpgkey: https://zoom.us/linux/download/pubkey?version=5-12-6
+    gpgkey: https://repo.zoom.us/repo/rpm/release/repodata/repomd.xml.key
     gpgcheck: yes
 
 - name: Install Zoom

--- a/tasks/zoom.yml
+++ b/tasks/zoom.yml
@@ -1,10 +1,16 @@
-- name: Import zoom RPM key
+# adapted from https://github.com/gantsign/ansible-role-visual-studio-code
+- name: Install Zoom repository
   become: yes
-  rpm_key:
-    key: https://zoom.us/linux/download/pubkey?version=5-12-6
-    
-- name: Install zoom and enable repo
+  yum_repository:
+    name: zoom
+    description: Zoom repository
+    file: zoom
+    baseurl: https://repo.zoom.us/repo/rpm/release/
+    gpgkey: https://zoom.us/linux/download/pubkey?version=5-12-6
+    gpgcheck: yes
+
+- name: Install Zoom
   become: yes
   package:
     name:
-      - https://zoom.us/client/latest/zoom_x86_64.rpm
+      - zoom


### PR DESCRIPTION
Zoom seems to have changed the setup of their repositories and seems to be working towards proper Linux repositories for automatic updates. I only got the relevant info via a support request, but was then handed a very nice Markdown document with valid instructions of how to configure the Zoom RPM repo. I have implemented these recommendations with this new setup and tested it by uninstalling Zoom (and repo and key) on my Framework laptop and rerunning the playbook. So this should be working (until Zoom decides on a different architecture)...