### PR TITLE
Feat: optional tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ You will be asked for the `BECOME password`. This is simply your user password.
 In order to adapt to changes in the workstation setup, simply rerun the playbook with the same command.
 Ansible will automatically only execute the changes.
 
-If you would like to add any optional packages, you can add the desired options to your 
-`~/.config/ansible/options.yml`. A template with existing options is found in `options-template.yml` 
+If you would like to add any optional packages, you can add the desired options to your
+`~/.config/ansible/options.yml`. A template with existing options is found in `options-template.yml`
 inside the repository.
 
 ### Step 5: Optionally enable fractional scaling of fonts (to get larger font sizes)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ git_email: johannes.koester@uni-due.de
 git_name: Johannes Koester
 ```
 
+In addition, create the file `~/.config/ansible/options.yml` by using
+`touch ~/.config/ansible/vars.yml`. If you do not want any optional packages installed,
+you can leave the file empty.
+
 ### Step 3: Clone the playbook repository
 
 ```sh
@@ -57,6 +61,9 @@ You will be asked for the `BECOME password`. This is simply your user password.
 In order to adapt to changes in the workstation setup, simply rerun the playbook with the same command.
 Ansible will automatically only execute the changes.
 
+If you would like to add any optional packages, you can add the desired options to your 
+`~/.config/ansible/options.yml`. A template with existing options is found in `options-template.yml` 
+inside the repository.
 
 ### Step 5: Optionally enable fractional scaling of fonts (to get larger font sizes)
 

--- a/options-template.yml
+++ b/options-template.yml
@@ -2,3 +2,5 @@ install_utils: false
 install_thunderbird: false
 install_gnome_tweaks: false
 install_gnome_extensions: false
+install_filezilla: false
+install_pixi: false

--- a/options-template.yml
+++ b/options-template.yml
@@ -1,0 +1,4 @@
+install_utils: false
+install_thunderbird: false
+install_gnome_tweaks: false
+install_gnome_extensions: false

--- a/playbook.yml
+++ b/playbook.yml
@@ -40,3 +40,7 @@
     - include_tasks: tasks/thunderbird.yml
 
     - include_tasks: tasks/gnome.yml
+
+    - include_tasks: tasks/filezilla.yml
+
+    - include_tasks: tasks/pixi.yml

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,8 +2,11 @@
 
   vars_files:
     - ~/.config/ansible/vars.yml
+    - ~/.config/ansible/options.yml
 
   tasks:
+    # mandatory tasks
+    
     - include_tasks: tasks/coprs.yml
 
     - include_tasks: tasks/framework.yml
@@ -29,3 +32,11 @@
     - include_tasks: tasks/misc.yml
 
     - include_tasks: tasks/conda.yml
+    
+    # optional tasks
+    
+    - include_tasks: tasks/util.yml
+
+    - include_tasks: tasks/thunderbird.yml
+
+    - include_tasks: tasks/gnome.yml

--- a/tasks/filezilla.yml
+++ b/tasks/filezilla.yml
@@ -1,0 +1,6 @@
+- name: Install packages
+  become: true
+  when: install_filezilla is defined and install_filezilla == true
+  package:
+    name:
+      - filezilla

--- a/tasks/gnome.yml
+++ b/tasks/gnome.yml
@@ -1,0 +1,20 @@
+- name: Install GNOME tweaks
+  become: true
+  when: install_gnome_tweaks is defined and install_gnome_tweaks == true
+  package:
+    name:
+      - gnome-tweaks
+
+- name: Ensure flatpak
+  become: true
+  when: install_gnome_extensions is defined and install_gnome_extensions == true
+  package:
+    name:
+      - flatpak
+
+- name: Install GNOME extension module
+  become: true
+  when: install_gnome_extensions is defined and install_gnome_extensions == true
+  community.general.flatpak:
+    name: org.gnome.Extensions
+    state: present

--- a/tasks/pixi.yml
+++ b/tasks/pixi.yml
@@ -1,0 +1,12 @@
+- name: Ensure curl is installed
+  become: true
+  package:
+    name: curl
+    state: present
+
+- name: Download and run Pixi install script
+  when: install_pixi is defined and install_pixi == true
+  shell: |
+    curl -fsSL https://pixi.sh/install.sh | bash
+  args:
+    executable: /bin/bash

--- a/tasks/thunderbird.yml
+++ b/tasks/thunderbird.yml
@@ -1,0 +1,6 @@
+- name: Install packages
+  become: true
+  when: install_thunderbird is defined and install_thunderbird == true
+  package:
+    name:
+      - thunderbird

--- a/tasks/util.yml
+++ b/tasks/util.yml
@@ -1,0 +1,6 @@
+- name: Install packages
+  become: true
+  when: install_utils is defined and install_utils == true
+  package:
+    name:
+      - htop


### PR DESCRIPTION
This PR adds some more packages to be installed:
- htop (in utils)
- Thunderbird
- Gnome tweaks and Gnome extensions

Since they might not be relevant for everyone, these new task are opt-in. One has to create an `options.yml` next to the existing `vars.yml`, where desired optional tasks can be set to true. This is done via varaibles. If a variable is not defined, the corresponding optional task will be skipped. A template containing all existing variables can be found in `options-teamplte.yml`. This file should be updated whenever new optional task files are added.

There are some open discussion points:
- One could move the optional variables to the `vars.yml`. This has the advantage that the file already exists.
- We could solve having optional tasks in a completely different way
- Gnome extensions require the installation of flatpaks. I am not very experienced in system integration but maybe there are concerns for our systems that I am not aware of.