### PR TITLE
fix: outdated package and command

### DIFF
--- a/tasks/multimedia.yml
+++ b/tasks/multimedia.yml
@@ -19,5 +19,4 @@
   become: true
   shell: |
     dnf swap ffmpeg-free ffmpeg --allowerasing -y
-    dnf groupupdate multimedia --setop="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin -y
-    dnf groupupdate sound-and-video -y
+    dnf group upgrade multimedia --setopt="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin -y


### PR DESCRIPTION
Removes one package from the multimedia playbook that is no available anymore. Fixes another command because syntax changed for Fedora 42.